### PR TITLE
fix: escape command name in processTracer chart

### DIFF
--- a/src/processTracer.ts
+++ b/src/processTracer.ts
@@ -219,13 +219,14 @@ export async function report(
 
       for (const command of filteredCommands) {
         const extraProcessInfo: string | null = getExtraProcessInfo(command)
+        const escapedName = command.name.replace(/:/g, '#colon;')
         if (extraProcessInfo) {
           chartContent = chartContent.concat(
             '\t',
-            `${command.name} (${extraProcessInfo}) : `
+            `${escapedName} (${extraProcessInfo}) : `
           )
         } else {
-          chartContent = chartContent.concat('\t', `${command.name} : `)
+          chartContent = chartContent.concat('\t', `${escapedName} : `)
         }
         if (command.exitCode !== 0) {
           // to show red


### PR DESCRIPTION
Fix invalid processTracer gantt output if a process name contains `:`