### PR TITLE
README: Add permissions to sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ To use the action, add the following step before the steps you want to track.
 
 ```yaml
 permissions:
+  actions: read
   pull-requests: write
 jobs:
   workflow-telemetry-action:


### PR DESCRIPTION
https://github.com/catchpoint/workflow-telemetry-action/blob/f974e0c5942f8f37973c4cc395704165fbe629ba/src/post.ts#L55-L58

This Actions needs `actions: read` permission.
Therefore, I add this permission to sample code in README.