### PR TITLE
Use the Github token from the action input

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,3 @@
-import * as core from '@actions/core'
 import * as stepTracer from './stepTracer'
 import * as statCollector from './statCollector'
 import * as processTracer from './processTracer'

--- a/src/post.ts
+++ b/src/post.ts
@@ -10,7 +10,9 @@ import { WorkflowJobType } from './interfaces'
 const { pull_request } = github.context.payload
 const { workflow, job, repo, runId, sha } = github.context
 const PAGE_SIZE = 100
-const octokit: Octokit = new Octokit()
+const octokit: Octokit = new Octokit({
+  auth: core.getInput('github_token')
+})
 
 async function getCurrentJob(): Promise<WorkflowJobType | null> {
   const _getCurrentJob = async (): Promise<WorkflowJobType | null> => {


### PR DESCRIPTION
When using your action I get the following error in the Post Collect Workflow Telemetry Step:

```
/home/runner/work/_actions/catchpoint/workflow-telemetry-action/v2/dist/node_modules/@octokit/auth-action/dist-node/index.js:44
    throw new Error(
^
Error: [@octokit/auth-action] The token variable is specified more than once. Use either `with.token`, `with.GITHUB_TOKEN`, or `env.GITHUB_TOKEN`. See https://github.com/octokit/auth-action.js#createactionauth
    at createActionAuth2 (/home/runner/work/_actions/catchpoint/workflow-telemetry-action/v2/dist/node_modules/@octokit/auth-action/dist-node/index.js:[4](https://github.com/********/actions/runs/995********/job/274********#step:16:4)4:1)
    at new Octokit (/home/runner/work/_actions/catchpoint/workflow-telemetry-action/v2/dist/node_modules/@octokit/action/node_modules/@octokit/core/dist-node/index.js:127:1)
    at new OctokitWithDefaults (/home/runner/work/_actions/catchpoint/workflow-telemetry-action/v2/dist/node_modules/@octokit/action/node_modules/@octokit/core/dist-node/index.js:42:1)
    at Object.70[5](https://github.com/********/actions/runs/995********/job/274********#step:16:5)1 (/home/runner/work/_actions/catchpoint/workflow-telemetry-action/v2/dist/src/post.ts:45:1)
    at __nccwpck_require__ (/home/runner/work/_actions/catchpoint/workflow-telemetry-action/v2/dist/webpack/bootstrap:21:1)
    at /home/runner/work/_actions/catchpoint/workflow-telemetry-action/v2/dist/webpack/startup:4:1
    at Object.<anonymous> (/home/runner/work/_actions/catchpoint/workflow-telemetry-action/v2/dist/post/index.js:[6](https://github.com/********/actions/runs/995********/job/274********#step:16:6)1679:12)
    at Module._compile (node:internal/modules/cjs/loader:1358:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1416:10)
    at Module.load (node:internal/modules/cjs/loader:1208:32)
```