### PR TITLE
Bump runtime to node24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,18 +3,18 @@ name: build-workflow-telemetry
 on:
   pull_request:
     branches:
-      - "master"
+      - 'master'
   workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version: 24
       - run: npm install
       - run: npm run all
       - name: Verify no unstage changes

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ inputs:
     required: false
 
 runs:
-  using: "node20"
+  using: "node24"
   main: dist/main/index.js
   post: dist/post/index.js
 branding:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workflow-telemetry-action",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workflow-telemetry-action",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-telemetry-action",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": false,
   "description": "Github action to collect metrics (CPU, memory, I/O, etc ...) from your workflows to help you debug and optimize your CI/CD pipeline",
   "main": "lib/main.js",


### PR DESCRIPTION
We are running this internally and it works fine 👍 

* Bump runtime to node24

node20 reaches GitHub Actions EOL 2026-04-30. Verified the packaged dist/ output is unchanged after rebuilding with node24 locally. No source compatibility issues.

* SHA-pin build.yml actions and test under node24

Required by the mixpanel org's sha_pinning_required policy. the PR-triggered build check wasn't running at all with tag-pinned actions. 